### PR TITLE
Refactor job building process

### DIFF
--- a/_grains/jenkins.py
+++ b/_grains/jenkins.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import json
+
+def main():
+    output = { "jenkins_plugins" : {} }
+
+    list_plugin_groovy = """\
+        pluginList = []
+        Jenkins.instance.pluginManager.plugins.each{ pluginList << ("'${it.shortName}@${it.version}'")}
+        print pluginList
+    """
+    call_result = __salt__['jenkins_common.call_groovy_script'](list_plugin_groovy, [])
+
+    plugins = json.loads(call_result)
+
+    for plugin in plugins:
+        plugin_fields = plugin.split('@')
+        output["jenkins_plugins"][plugin_fields[0]] = {"version": plugin_fields[1]}
+
+    if output:
+        return output
+    else:
+        return None

--- a/_states/jenkins_job.py
+++ b/_states/jenkins_job.py
@@ -11,6 +11,14 @@ import salt.utils
 
 # Import XML parser
 import xml.etree.ElementTree as ET
+import hashlib
+
+# Jenkins
+try:
+  import jenkins
+  HAS_JENKINS = True
+except ImportError:
+  HAS_JENKINS = False
 
 log = logging.getLogger(__name__)
 
@@ -19,7 +27,7 @@ def __virtual__():
     '''
     Only load if jenkins_common module exist.
     '''
-    if 'jenkins_common.call_groovy_script' not in __salt__:
+    if HAS_JENKINS and 'jenkins_common.call_groovy_script' not in __salt__:
         return (
             False,
             'The jenkins_job state module cannot be loaded: '
@@ -28,17 +36,7 @@ def __virtual__():
 
 
 def _elements_equal(e1, e2):
-    if e1.tag != e2.tag:
-        return False
-    if e1.text != e2.text:
-        return False
-    if e1.tail != e2.tail:
-        return False
-    if e1.attrib != e2.attrib:
-        return False
-    if len(e1) != len(e2):
-        return False
-    return all(_elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
+    return hashlib.md5(e1).hexdigest() == hashlib.md5(e2).hexdigest()
 
 
 def present(name,
@@ -63,16 +61,23 @@ def present(name,
         ret['changes'][name] = status
         ret['comment'] = 'Job %s %s' % (name, status.lower())
     else:
-        _job_exists = __salt__['jenkins.job_exists'](name)
-        if _job_exists:
+        _current_job_config = ''
+        _job_exists = True
+        try:
             _current_job_config = __salt__['jenkins.get_job_config'](name)
+        except jenkins.NotFoundException:
+            _job_exists = False
+
+        if _job_exists:
             buf = six.moves.StringIO(_current_job_config)
-            oldXML = ET.fromstring(buf.read())
+            oldXMLstring = buf.read()
 
             cached_source_path = __salt__['cp.cache_file'](config, __env__)
             with salt.utils.fopen(cached_source_path) as _fp:
-                newXML = ET.fromstring(_fp.read())
-            if not _elements_equal(oldXML, newXML):
+                newXMLstring = _fp.read()
+            if not _elements_equal(oldXMLstring, newXMLstring):
+                oldXML = ET.fromstring(oldXMLstring)
+                newXML = ET.fromstring(newXMLstring)
                 diff = difflib.unified_diff(
                     ET.tostringlist(oldXML, encoding='utf8', method='xml'),
                     ET.tostringlist(newXML, encoding='utf8', method='xml'), lineterm='')

--- a/jenkins/files/jobs/workflow-scm.xml
+++ b/jenkins/files/jobs/workflow-scm.xml
@@ -2,13 +2,12 @@
 {%- if job is not defined -%}
   {%- set job = salt['pillar.get']('jenkins:client:job:'+job_name) -%}
 {%- endif -%}
-
 <?xml version='1.0' encoding='UTF-8'?>
-<flow-definition plugin="workflow-job@2.6">
+<flow-definition plugin="workflow-job@{% salt['grains.get']('jenkins_plugins:workflow-job:version') %}">
   {%- include "jenkins/files/jobs/_common.xml" %}
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin="workflow-cps@2.13">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition" plugin=workflow-cps@"{% salt['grains.get']('jenkins_plugins:workflow-cps:version') %}">
     {%- if job.scm.get('type', 'git') == 'git' %}
-    <scm class="hudson.plugins.git.GitSCM" plugin="git@2.5.3">
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@{% salt['grains.get']('jenkins_plugins:git:version') %}">
       <configVersion>2</configVersion>
       <userRemoteConfigs>
         <hudson.plugins.git.UserRemoteConfig>

--- a/jenkins/files/jobs/workflow.xml
+++ b/jenkins/files/jobs/workflow.xml
@@ -16,7 +16,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <flow-definition plugin="workflow-job@2.5">
   {%- include "jenkins/files/jobs/_common.xml" %}
-  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.12">
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@{% salt['grains.get']('jenkins_plugins:workflow-cps:version') %}">
     <script>// libraries
 {%- if job.libs is defined %}
 {%- for lib in job.libs %}


### PR DESCRIPTION
Use MD5 to compare Jenkins jobs.
Add grains with Jenkins' plugins and their versions and use the grains in the default xml templates.