### PR TITLE
Python3 support

### DIFF
--- a/_grains/jenkins_plugins.py
+++ b/_grains/jenkins_plugins.py
@@ -31,6 +31,6 @@ def main():
     except jenkins.JenkinsException:
         return {}
 
-    for plugin_name, plugin_dict in plugins.iteritems():
+    for plugin_name, plugin_dict in plugins.items():
         output["jenkins_plugins"][plugin_name[0]] = {"version" : (plugin_dict["version"] or 0)}
     return output

--- a/_modules/jenkins_common.py
+++ b/_modules/jenkins_common.py
@@ -152,7 +152,7 @@ def encode_password(password):
     :returns: bcrypt hashed password
     """
     if isinstance(password, str):
-        return bcrypt.hashpw(password, bcrypt.gensalt(prefix=b"2a"))
+        return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt(prefix=b"2a"))
 
 def load_template(salt_url, env):
     """
@@ -194,4 +194,3 @@ def api_call(name, template, success_msgs, params, display_name):
                 "msg"])
     ret['result'] = None if test else result
     return ret
-

--- a/jenkins/client/_job_template.sls
+++ b/jenkins/client/_job_template.sls
@@ -1,7 +1,7 @@
 {%- if job_template.get('enabled', true) %}
   {#- Matrix way, simulating behavior of Jenkins job builder, not fully
       supported at the moment #}
-  {%- for param_name, params in job_template.get('param', {}).iteritems() %}
+  {%- for param_name, params in job_template.get('param', {}).items() %}
     {%- set replacer = client.replacer.open + param_name + client.replacer.close %}
     {%- for param in params %}
       {%- set job_name = job_template.name|replace(replacer, param) %}
@@ -15,7 +15,7 @@
     {%- set _job_name = [job_template.name] %}
     {%- set _job = [job_template.template] %}
 
-    {%- for key, value in job_params.iteritems() %}
+    {%- for key, value in job_params.items() %}
       {#- You may think WTF hack is this but we can't update variables in
           inner scope to replace all parameters. But we can abuse lists for
           this purpose }:-) #}

--- a/jenkins/client/artifactory.sls
+++ b/jenkins/client/artifactory.sls
@@ -1,6 +1,6 @@
 {#- It's not recommended to call this state explicitly as it requires plugins and credentials #}
 {% from "jenkins/map.jinja" import client with context %}
-{% for name, artifactory in client.get('artifactory',{}).iteritems() %}
+{% for name, artifactory in client.get('artifactory',{}).items() %}
 {% if artifactory.get('enabled', True) %}
 jenkins_artifactory_server_{{ name }}:
   jenkins_artifactory.present:

--- a/jenkins/client/credential.sls
+++ b/jenkins/client/credential.sls
@@ -1,6 +1,6 @@
 {#- It's not recommended to call this state explicitly as it requires plugins #}
 {% from "jenkins/map.jinja" import client with context %}
-{% for name, cred in client.get('credential',{}).iteritems() %}
+{% for name, cred in client.get('credential',{}).items() %}
 credential_{{ name }}:
   jenkins_credential.present:
   - name: {{ cred.get('name', name) }}

--- a/jenkins/client/gerrit.sls
+++ b/jenkins/client/gerrit.sls
@@ -1,7 +1,7 @@
 {#- It's not recommended to call this state explicitly as it requires plugins #}
 {% from "jenkins/map.jinja" import client with context %}
 {%- if client.gerrit is defined %}
-{% for name, gerrit in client.get('gerrit',{}).iteritems() %}
+{% for name, gerrit in client.get('gerrit',{}).items() %}
 jenkins_gerrit_trigger_{{ name }}:
   jenkins_gerrit.present:
   - name: {{ name }}

--- a/jenkins/client/globalenvprop.sls
+++ b/jenkins/client/globalenvprop.sls
@@ -1,5 +1,5 @@
 {% from "jenkins/map.jinja" import client with context %}
-{% for name, prop in client.get('globalenvprop',{}).iteritems() %}
+{% for name, prop in client.get('globalenvprop',{}).items() %}
 {% if prop.get('enabled', True) %}
 prop_{{ name }}:
   jenkins_globalenvprop.present:

--- a/jenkins/client/jira.sls
+++ b/jenkins/client/jira.sls
@@ -4,7 +4,7 @@
 jenkins_jira_enable:
   jenkins_jira.present:
     - sites: {
-      {% for name, site in client.jira.get('sites',[]).iteritems() %}
+      {% for name, site in client.jira.get('sites',[]).items() %}
       '{{ name }}': {
         link_url: '{{ site.get('link_url', name) }}',
         http_auth: {{ site.get('http_auth', false) }},

--- a/jenkins/client/job.sls
+++ b/jenkins/client/job.sls
@@ -2,7 +2,7 @@
  in the end of Jenkins instance configuration #}
 {% from "jenkins/map.jinja" import client with context %}
 
-{%- for job_name, job in client.get('job', {}).iteritems() %}
+{%- for job_name, job in client.get('job', {}).items() %}
   {%- include "jenkins/client/_job.sls" %}
 {%- endfor %}
 
@@ -10,9 +10,9 @@
 
   {%- set jobs =  client.get('job', {}).keys() %}
 
-  {%- for job_template_name, job_template in client.get('job_template', {}).iteritems() %}
+  {%- for job_template_name, job_template in client.get('job_template', {}).items() %}
     {%- if job_template.get('enabled', true) %}
-      {%- for param_name, params in job_template.get('param', {}).iteritems() %}
+      {%- for param_name, params in job_template.get('param', {}).items() %}
         {%- set replacer = client.replacer.open + param_name + client.replacer.close %}
         {%- for param in params %}
           {%- set job_name = job_template.name|replace(replacer, param) %}
@@ -22,7 +22,7 @@
 
       {%- for job_params in job_template.get('jobs', []) %}
         {%- set job_name = job_template.name %}
-        {%- for key, value in job_params.iteritems() %}
+        {%- for key, value in job_params.items() %}
           {%- set replacer = client.replacer.open + key + client.replacer.close %}
           {%- set job_name = job_name|replace(replacer, value) %}
           {%- do jobs.append(job_name) %}

--- a/jenkins/client/job_template.sls
+++ b/jenkins/client/job_template.sls
@@ -17,7 +17,7 @@
 
 {%- else %}
 
-{%- for job_template_name, job_template in client.get('job_template', {}).iteritems() %}
+{%- for job_template_name, job_template in client.get('job_template', {}).items() %}
 {% include "jenkins/client/_job_template.sls" %}
 {%- endfor %}
 

--- a/jenkins/client/lib.sls
+++ b/jenkins/client/lib.sls
@@ -1,6 +1,6 @@
 {#- It's not recommended to call this state explicitly as it requires plugins and credentials #}
 {% from "jenkins/map.jinja" import client with context %}
-{% for name, lib in client.get("lib",{}).iteritems() %}
+{% for name, lib in client.get("lib",{}).items() %}
 {%- if lib.enabled|default(True) %}
     global_library_{{ name }}:
       jenkins_lib.present:

--- a/jenkins/client/node.sls
+++ b/jenkins/client/node.sls
@@ -1,6 +1,6 @@
 {#- It's not recommended to call this state explicitly as it may require plugins #}
 {% from "jenkins/map.jinja" import client with context %}
-{% for name, node in client.get("node",{}).iteritems() %}
+{% for name, node in client.get("node",{}).items() %}
 {% if node.get('name', name) == "master" %}
 master_configuration:
   jenkins_node.setup_master:
@@ -20,7 +20,7 @@ node_{{ name }}:
     - labels: {{ node.get('labels',[]) }}
 {% endif %}
 {%- endfor %}
-{% for node_name, label in client.get("label",{}).iteritems() %}
+{% for node_name, label in client.get("label",{}).items() %}
 label_for_{{ node_name }}:
   jenkins_node.label:
     - name: {{ node_name }}

--- a/jenkins/client/source.sls
+++ b/jenkins/client/source.sls
@@ -1,7 +1,7 @@
 {#- This state isn't designed to be called explicitly #}
 {% from "jenkins/map.jinja" import client with context %}
 
-{%- for source_name, source in client.get('source', {}).iteritems() %}
+{%- for source_name, source in client.get('source', {}).items() %}
 
 {%- if source.engine == "git" %}
 

--- a/jenkins/client/throttle_category.sls
+++ b/jenkins/client/throttle_category.sls
@@ -1,6 +1,6 @@
 {#- It's not recommended to call this state explicitly as it requires plugins #}
 {% from "jenkins/map.jinja" import client with context %}
-{% for name, throttle_category in client.get("throttle_category",{}).iteritems() %}
+{% for name, throttle_category in client.get("throttle_category",{}).items() %}
 {% if throttle_category.get('enabled', True) %}
 'throttle_category_{{ name }}':
   jenkins_throttle_category.present:

--- a/jenkins/client/user.sls
+++ b/jenkins/client/user.sls
@@ -1,6 +1,6 @@
 {% from "jenkins/map.jinja" import client with context %}
 
-{% for name, user in client.get('user',{}).iteritems() %}
+{% for name, user in client.get('user',{}).items() %}
 user_{{ name }}:
   jenkins_user.present:
   - username: {{ name }}

--- a/jenkins/client/view.sls
+++ b/jenkins/client/view.sls
@@ -1,11 +1,11 @@
 {#- It's not recommended to call this state explicitly as it requires plugins #}
 {% from "jenkins/map.jinja" import client with context %}
-{% for name, view in client.get('view',{}).iteritems() %}
+{% for name, view in client.get('view',{}).items() %}
 {% if view.get('enabled', True) %}
 view_{{ name }}:
   jenkins_view.present:
   - name: {{ view.get('name', name) }}
-  {%- for key, value in view.iteritems() %}
+  {%- for key, value in view.items() %}
   {%- if key != "name" %}
   - {{ key }}: {{ value }}
   {%- endif %}

--- a/jenkins/files/jobs/_common.xml
+++ b/jenkins/files/jobs/_common.xml
@@ -23,7 +23,7 @@
     {%- endif %}
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers>
-        {%- for type, trigger in job.get('trigger', {}).iteritems() %}
+        {%- for type, trigger in job.get('trigger', {}).items() %}
         {%- if trigger.enabled|default(True) %}
         {%- if type == 'reverse' %}
         <jenkins.triggers.ReverseBuildTrigger>
@@ -58,7 +58,7 @@
         <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger plugin="gerrit-trigger@{{ salt['grains.get']('jenkins_plugins:gerrit-trigger:version', '2.23.0') }}">
           <spec/>
           <gerritProjects>
-            {%- for pname, project in trigger.project.iteritems() %}
+            {%- for pname, project in trigger.project.items() %}
             <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
               <compareType>{{ project.compare_type|default("PLAIN") }}</compareType>
               <pattern>{{ project.name|default(pname) }}</pattern>
@@ -93,7 +93,7 @@
           <commitMessageParameterMode>BASE64</commitMessageParameterMode>
           <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
           <commentTextParameterMode>BASE64</commentTextParameterMode>
-          {%- for override_key, override_value in trigger.get('override-votes', {}).iteritems() %}
+          {%- for override_key, override_value in trigger.get('override-votes', {}).items() %}
           <{{ override_key }}>{{ override_value }}</{{ override_key }}>
           {%- endfor %}
           {%- set message = trigger.get('message', {}).build_start|default("") %}
@@ -141,7 +141,7 @@
           <serverName>{{ trigger.get('server', client.get('trigger_gerrit_server', '__ANY__')) }}</serverName>
           {%- if trigger.event is defined %}
           <triggerOnEvents>
-            {%- for ename, actions in trigger.event.iteritems() %}
+            {%- for ename, actions in trigger.event.items() %}
               {%- for action in actions %}
                 {%- if action is mapping %}
                   {%- set action_name = action.keys().0 %}
@@ -161,7 +161,7 @@
 
                 {%- if action_param is defined %}
             <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.Plugin{{ ename|title }}{{ _name_list|join('') }}Event>
-                  {%- for key, value in action_param.iteritems() %}
+                  {%- for key, value in action_param.items() %}
               <{{ key }}>{{ value }}</{{ key }}>
                   {%- endfor %}
             </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.Plugin{{ ename|title }}{{ _name_list|join('') }}Event>

--- a/jenkins/files/jobs/_parameters.xml
+++ b/jenkins/files/jobs/_parameters.xml
@@ -1,7 +1,7 @@
 {%- if job.param is defined %}
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
-        {%- for param_name, param in job.param.iteritems() %}
+        {%- for param_name, param in job.param.items() %}
         <hudson.model.{{ param.get('type', 'string')|capitalize }}ParameterDefinition>
           <name>{{ param_name }}</name>
           {%- if param.description is defined %}

--- a/jenkins/files/pbuilderrc
+++ b/jenkins/files/pbuilderrc
@@ -60,9 +60,9 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH:"}/usr/lib/libeatmyd
 export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}libeatmydata.so"
 {%- endif %}
 
-{%- for os, distribution in slave.pbuilder.get('os', {}).iteritems() %}
+{%- for os, distribution in slave.pbuilder.get('os', {}).items() %}
 if [ "$OS" == "{{ os }}" ]; then
-    {%- for dist_name, dist in distribution.iteritems() %}
+    {%- for dist_name, dist in distribution.items() %}
     if [ "$DIST" == "{{ dist_name }}" ]; then
         DISTRIBUTION="$DIST"
         MIRRORSITE="{{ dist.mirrorsite }}"

--- a/jenkins/files/slave/pbuilderrc
+++ b/jenkins/files/slave/pbuilderrc
@@ -60,9 +60,9 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+"$LD_LIBRARY_PATH:"}/usr/lib/libeatmyd
 export LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}libeatmydata.so"
 {%- endif %}
 
-{%- for os, distribution in slave.pbuilder.get('os', {}).iteritems() %}
+{%- for os, distribution in slave.pbuilder.get('os', {}).items() %}
 if [ "$OS" == "{{ os }}" ]; then
-    {%- for dist_name, dist in distribution.iteritems() %}
+    {%- for dist_name, dist in distribution.items() %}
     if [ "$DIST" == "{{ dist_name }}" ]; then
         DISTRIBUTION="$DIST"
         MIRRORSITE="{{ dist.mirrorsite }}"

--- a/jenkins/master/user.sls
+++ b/jenkins/master/user.sls
@@ -1,6 +1,6 @@
 {% from "jenkins/map.jinja" import master with context %}
 
-{%- for user_name, user in master.user.iteritems() %}
+{%- for user_name, user in master.user.items() %}
 
 {{ master.home }}/users/{{ user_name }}:
   file.directory:

--- a/jenkins/meta/config.yml
+++ b/jenkins/meta/config.yml
@@ -29,7 +29,7 @@ config:
     template: jinja
   {%- endif %}
 
-  {%- for user_name, user in master.get('user', {}).iteritems() %}
+  {%- for user_name, user in master.get('user', {}).items() %}
   {{ user_name }}_config.yml:
     path: {{ master.home }}/users/{{ user_name }}/config.xml
     source: "salt://jenkins/files/config.xml.user"


### PR DESCRIPTION
Add python 3 support in order to be able to support modern salt installations that no longer use the out-of-date python2.

I have not tested it extensively, but these modifications were enough for me using python 3.6.8 on CentOS 7.